### PR TITLE
Introduce ADBC instead of ODBC to interact with the Postgres API, implement a read by chunks, remove the `id` column at the `stock` table to improve write speed

### DIFF
--- a/.docker/cli/Dockerfile
+++ b/.docker/cli/Dockerfile
@@ -1,19 +1,7 @@
-FROM alpine:3.19 as cli
+FROM python:3.9.18-bullseye as cli
 
 VOLUME app
 WORKDIR app
-
-RUN apk update --no-cache && \
-    apk add \
-        bash=5.2.21-r0 \
-        postgresql-client \
-        python3=3.11.6-r1 \
-        python3-dev \
-        py3-pip \
-        gcc \
-        musl-dev \
-        postgresql-libs \
-        postgresql-dev
 
 COPY src/requirements.txt app/requirements.txt
 # The `--break-system-packages` flag is used beacuse the Alpine distro can install Python packages.

--- a/.docker/db-postgres/0-dml.sql
+++ b/.docker/db-postgres/0-dml.sql
@@ -1,8 +1,6 @@
 CREATE TABLE stock (
-  id uuid,
   point_of_sale VARCHAR(6),
   product VARCHAR(63),
   date TIMESTAMP,
-  stock float8,
-  PRIMARY KEY (id)
+  stock float8
 );

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Ingest data using an extensive data source and place it into a data repository.
 The assessment is based on [Python](https://www.python.org), the solution has a naive
 implementation and there is no exist a "strong" optimization implemented.
 
+A constraint for this project expose that the implementation won't use `COPY` or any bulk import
+mechanism that is native to [Postgres](https://www.postgresql.org).
+
 ## Index
 
 - [TL;DR](#tldr)
@@ -12,12 +15,13 @@ implementation and there is no exist a "strong" optimization implemented.
 - [Project structure](#project-structure)
 - [Execution flow](#execution-flow)
 - [Docker information](#docker-information)
+- [Benchmark](#benchmark)
 - [Notes](#notes)
 
 
 ## Tl;DR
 
-If you want to start the project, go ahead and observe the [Execution flow](#execution-flow). My 
+If you want to start the project, go ahead and observe the [Execution flow](#execution-flow). My
 recommendation is to read this `README.md` if it is your first time around here.
 
 ## Data flow
@@ -25,10 +29,10 @@ recommendation is to read this `README.md` if it is your first time around here.
 The data flow goes in this way:
 
 - A clean of the data repository is conducted;
-- Read of the entire file (no chunk in here where implemented);
+- Read of the entire file;
 - Data connection (there is no existence of a connection pool);
 - A data repository where to insert data will be allowed to store the rows collected;
-    - A chunk is used in order to "limit" the quantity of rows to pass on a SQL transaction.
+    - A chunk is used in order to "limit" the quantity of rows to pass to the SQL transaction.
 
 ## Project structure
 
@@ -73,39 +77,63 @@ docker compose -f .docker/compose.yaml run --rm cli python3 main.py \
 # Run this if your data input has many rows. Increment the chunk argument as you want.
 # Keep in mind that there is not optimization and a well-resource approach is no implemented (yet).
 docker compose -f .docker/compose.yaml run --rm cli python3 main.py \
-    --chunk 250000
+    --chunk 250000 \
     --csv public/data/stockExample.csv
 
 # Run only the data insertion flow.
 docker compose -f .docker/compose.yaml run --rm cli python3 main.py \
-    --clean false --csv public/data/stockExample.csv --insert true
+    --clean false \
+    --csv public/data/stockExample.csv \
+    --insert true
 
-# Run only the data insertion flow, chunk size is set to 1000 rows and handle the first 1000 rows.
+# Run only the data insertion flow, chunk size is set to 1000 rows.
 docker compose -f .docker/compose.yaml run --rm cli python3 main.py \
-    --chunk 1000 --clean false --csv public/data/stockExample.csv  --insert true --row-limit 1000
+    --chunk 1000 \
+    --clean false \
+    --csv public/data/stockExample.csv \
+    --insert true
 ```
 
 ## Docker information
 
-As I am using "Docker" for containerization purposes, during my development flow I have this
-versions on my host machine.
+As I am using [Docker](https://www.docker.com) for containerization purposes, during my development
+flow I have this versions on my host machine.
 
 ```bash
 # `docker --version`
 Docker version 24.0.5, build ced0996
 
 # `docker compose version`
-docker-compose version
 Docker Compose version v2.20.2-desktop.1
 ```
+
+## Benchmarks
+
+The next comparison of chunks where called "benchmarks". The hardware use is the next one:
+
+- CPU: M1 Pro;
+- RAM: 16 GB;
+- SSD as hard disk drive.
+
+The Docker Desktop that I have been use has a limit of 5 Cores and 8 GB of RAM for the containers
+that runs this tests:
+
+| Rows      | Using DB index    | No DB index   |
+|:---------:|:-----------------:|:-------------:|
+| 100.000   |  34.030 secs.     | 0.8436 secs.  |
+| 300.000   |  118.5797 secs.   | 4.7773 secs.  |
+| 500.000   |  168.2027 secs.   | 6.8604 secs.  |
+| 700.000   |  237.8263 secs.   | 14.3700 secs. |
+| 1.000.000 |  186.8643 secs.   | 16.8604 secs. |
+| 5.000.000 |  Unknown secs.    | Unknown secs. |
+
+The time shown in the previous table is approximate, feel free to run it on your own hardware.
+
+For the last insertion stage a few exceptions where experienced and no solution where implemented yet.
 
 ## Notes
 
 - There is no:
-    - Optimization implemented, that means that if and extensive data source is used a
-        long time will be required and a lot of free physical memory will be used in order to
-        complete the data transfer;
-    - Chunk during the reading stage, the entire file has to be read it;
     - A SQL injection verification, the `.csv` can damage the entire data infrastructure layer;
     - The typical "virtual environment" approach, please use the containerization technology in 
         order to avoid damage on your own host.

--- a/src/database/Config.py
+++ b/src/database/Config.py
@@ -1,5 +1,6 @@
 import os
-import psycopg2
+
+import adbc_driver_postgresql.dbapi
 
 
 class Config:
@@ -7,16 +8,11 @@ class Config:
     def __init__(self) -> None:
         self.__connection = None
 
-    def getConnection(self) -> None:
-        self.__connection = psycopg2.connect(
-            host=os.environ.get('POSTGRES_HOST'),
-            database=os.environ.get('POSTGRES_DB'),
-            user=os.environ.get('POSTGRES_USER'),
-            password=os.environ.get('POSTGRES_PASSWORD'),
-        )
-        self.__connection.set_session(autocommit=True)
+    def get_arrow_connection(self) -> None:
+        uri: str = f"postgresql://{os.environ.get('POSTGRES_HOST')}:5432/{os.environ.get('POSTGRES_DB')}?user={os.environ.get('POSTGRES_USER')}&password={os.environ.get('POSTGRES_PASSWORD')}"
+        self.__connection = adbc_driver_postgresql.dbapi.connect(uri)
 
         return self.__connection
 
-    def closeConnection(self) -> None:
+    def close_connection(self) -> None:
         self.__connection.close()

--- a/src/ingest/FileHandler.py
+++ b/src/ingest/FileHandler.py
@@ -1,23 +1,17 @@
-# i call this directory "ingest" because we can retrieve data from different data sources
-
-# file handler
 import csv
+import traceback
 from typing import Dict, List
+
+import pandas
+
 
 class FileHandler:
 
     def __init__(self):
-        self.__fileLocation: str = ''
         pass
 
-    # def setFileLocation(self, fileLocation) -> None:
-    #     self.__fileLocation = fileLocation
-            
-
     def read(self, fileLocation: str) -> List[Dict]:
-        """
-        Read the files and return a list of dictionaries.
-        """
+        print('>> Reading the input file.')
         with open(fileLocation, 'r', encoding="utf-8-sig") as f:
             reader = csv.reader(f, delimiter=';')
 
@@ -38,10 +32,28 @@ class FileHandler:
             f.close()
 
         return out
+    
+    def read_by_chunks(self, fileLocation: str, chunkSize: int, skipRows: int) -> List[Dict]:
+        try:
+            with pandas.read_csv(
+                filepath_or_buffer=fileLocation,
+                delimiter=';',
+                chunksize=chunkSize,
+                encoding='utf-8-sig',
+                low_memory=False,
+                skiprows=skipRows
+            ) as reader:
+                df = reader.get_chunk()
+                data = [series[1].to_dict() for series in df.iterrows()]
 
-    def write(self, fileLocation):
-        # No implemented.
-        pass
+                return data
 
-    # def describeHeaders():
+        except pandas.errors.EmptyDataError as err:
+            print('>> No more data will be collected.')
+            
+            return []
 
+        except Exception as err:
+            traceback.print_exception(value=None, tb=err, etype=BaseException)
+
+            return []

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,3 @@
-psycopg2==2.9.9
+adbc-driver-postgresql==0.9.0
+pyarrow==15.0.0
+pandas==2.2.0

--- a/src/store/SqlStore.py
+++ b/src/store/SqlStore.py
@@ -1,21 +1,18 @@
-from psycopg2.extensions import connection as psqlConnection
-from psycopg2 import ProgrammingError
+import traceback
 
 
 class SqlStore:
-    def __init__(self, connection: psqlConnection):
+    def __init__(self, connection):
         self.connection = connection
 
     def execute(self, sql: str) -> None:
-        result = None
-
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
-                result = cursor.fetchone()
 
-            return result
+                self.connection.commit()
+            
+            return None
 
-        except ProgrammingError:
-            # No action while the cursor do not transfer any data.
-            pass
+        except Exception as err:
+            traceback.print_exception(value=None, tb=err, etype=BaseException)


### PR DESCRIPTION
| Word             | Answer
| ------------- | ---
| Branch        | main
| Tickets | n/a
| License       | MIT License

## Info

Considering that the commit title do not represent the entire changes due the short expressiveness, I will introduce a more detailed list related to the changes that this PR introduce:

- The `Dockerifile` file change the image to `python:3.9.18-bullseye` after found problems on Alpine and the `adbc-driver-postgresql` dependency;
- The public methods where written in snake case instead of camel case;
- The table `stock` do not requires the `id` column anymore, in order to speed up the write;
- A chunk where implemented using the `pandas.read_csv()` public method, in order to "control" the resources invested in the reading staged;
- A few commented lines where removed to reduce the ambiguous sections;
- The `README.md` file now introduce the `Benchmark` section that expose a few list of insertion speed comparison.
